### PR TITLE
includes is not supported by ie11

### DIFF
--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -439,7 +439,7 @@ function makeOriginal(userTheme = {}) {
     'warning',
     'danger',
   ].forEach((type) => {
-    if (v[`$btn-${type}-bg`].includes('linear-gradient')) {
+    if (v[`$btn-${type}-bg`].indexOf('linear-gradient') !== -1) {
       v[`$btn-${type}-border`] = v[`$btn-${type}-bg`].match(linearGradientRe)[1]; // eslint-disable-line prefer-destructuring
     } else if (type === 'secondary') {
       // secondary is having a white background, they use by default #ccc to make it look like a button


### PR DESCRIPTION
fix: using indexOf !== -1 will produce the same results as includes, but is compatible with more browsers without polyfills

## bootstrap-styled

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/bootstrap-styled/bootstrap-styled/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/bootstrap-styled/bootstrap-styled/blob/master/.github/CONTRIBUTING.md)
- [ ] Double-check your branch is based on `dev` and targets `dev`
- [ ] Your are doing semantic commit message using [commitizen](https://github.com/commitizen/cz-cli) and our [commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
- [ ] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [ License](https://github.com/bootstrap-styled/bootstrap-styled/blob/master/LICENSE.md).
